### PR TITLE
Use correct icon for GitHub.

### DIFF
--- a/views/account/settings/index.jade
+++ b/views/account/settings/index.jade
@@ -38,7 +38,7 @@ block body
               |  Disconnect GitHub
           else
             a.btn.btn-block.btn-info(href='/account/settings/github/')
-              i.icon-twitter.icon-large
+              i.icon-github.icon-large
               |  Connect GitHub
         if oauthFacebook
           if oauthFacebookActive


### PR DESCRIPTION
The icon for connecting to GitHub in the account settings page was incorrect. (I edited the file in the browser, so the extra newline at the end of the file was added automatically.)
