### PR TITLE
re-enable buttons after getting the same error message from the server

### DIFF
--- a/public/views/contact/index.js
+++ b/public/views/contact/index.js
@@ -38,6 +38,8 @@
     },
     contact: function() {
       this.$el.find('.btn-contact').attr('disabled', true);
+	  this.model.attributes.errors = [];
+	  this.model.attributes.errfor = {};
       
       this.model.save({
         name: this.$el.find('[name="name"]').val(),

--- a/public/views/login/forgot/index.js
+++ b/public/views/login/forgot/index.js
@@ -43,6 +43,8 @@
     },
     forgot: function() {
       this.$el.find('.btn-forgot').attr('disabled', true);
+      this.model.attributes.errors = [];
+      this.model.attributes.errfor = {};
       
       this.model.save({
         email: this.$el.find('[name="email"]').val()

--- a/public/views/login/index.js
+++ b/public/views/login/index.js
@@ -43,6 +43,8 @@
     },
     login: function() {
       this.$el.find('.btn-login').attr('disabled', true);
+      this.model.attributes.errors = [];
+      this.model.attributes.errfor = {};
       
       this.model.save({
         username: this.$el.find('[name="username"]').val(),

--- a/public/views/login/reset/index.js
+++ b/public/views/login/reset/index.js
@@ -46,6 +46,8 @@
     },
     reset: function() {
       this.$el.find('.btn-reset').attr('disabled', true);
+      this.model.attributes.errors = [];
+      this.model.attributes.errfor = {};
       
       this.model.save({
         password: this.$el.find('[name="password"]').val(),

--- a/public/views/signup/index.js
+++ b/public/views/signup/index.js
@@ -44,6 +44,8 @@
     },
     signup: function() {
       this.$el.find('.btn-signup').attr('disabled', true);
+      this.model.attributes.errors = [];
+      this.model.attributes.errfor = {};
       
       this.model.save({
         username: this.$el.find('[name="username"]').val(),

--- a/public/views/signup/social.js
+++ b/public/views/signup/social.js
@@ -42,6 +42,8 @@
     },
     signup: function() {
       this.$el.find('.btn-signup').attr('disabled', true);
+      this.model.attributes.errors = [];
+      this.model.attributes.errfor = {};
       
       this.model.save({
         email: this.$el.find('[name="email"]').val()


### PR DESCRIPTION
If I try to log in and receive the "invalid username or password" error, then try to log in again but receive the same error message, the submit button does not get re-enabled in my browser.

Maybe there's a better way to fix this issue, but this seemed to work for me in testing locally.
