### PR TITLE
Allow sensitive information to be declared in env.

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,17 +37,17 @@ app.configure(function(){
   app.set('admin-email', 'your@email.addy');
   app.set('crypto-key', process.env.CRYPTO_KEY || 'k3yb0ardc4t');
   app.set('require-account-verification', false);
-  
-  //email (smtp) settings
-  app.set('email-from-name', app.get('project-name')+ ' Website');
-  app.set('email-from-address', 'your@email.addy');
-  app.set('email-credentials', {
-    user: 'your@email.addy',
-    password: process.env.EMAIL_PASSWORD || 'bl4rg!',
-    host: 'smtp.gmail.com',
-    ssl: true
+
+  //smtp settings
+  app.set('smtp-from-name', process.env.SMTP_FROM_NAME || app.get('project-name')+ ' Website');
+  app.set('smtp-from-address', process.env.SMTP_FROM_ADDRESS || 'your@email.addy');
+  app.set('smtp-credentials', {
+      user: process.env.SMTP_USERNAME || 'your@email.addy',
+      password: process.env.SMTP_PASSWORD || 'bl4rg!',
+      host: process.env.SMTP_HOST || 'smtp.gmail.com',
+      ssl: /yes|true/.test(process.env.SMTP_USE_SSL) || true
   });
-  
+
   //twitter settings
   app.set('twitter-oauth-key', process.env.TWITTER_OAUTH_KEY || '');
   app.set('twitter-oauth-secret', process.env.TWITTER_OAUTH_SECRET || '');

--- a/utilities/sendmail.js
+++ b/utilities/sendmail.js
@@ -69,7 +69,7 @@ exports = module.exports = function(req, res, options) {
       }
       
       var emailjs = require('emailjs/email');
-      var emailer = emailjs.server.connect( req.app.get('email-credentials') );
+      var emailer = emailjs.server.connect( req.app.get('smtp-credentials') );
       emailer.send({
         from: options.from,
         to: options.to,

--- a/views/account/verification/index.js
+++ b/views/account/verification/index.js
@@ -2,7 +2,7 @@
 
 var sendVerificationEmail = function(req, res, options) {
   req.app.utility.sendmail(req, res, {
-    from: req.app.get('email-from-name') +' <'+ req.app.get('email-from-address') +'>',
+    from: req.app.get('smtp-from-name') +' <'+ req.app.get('smtp-from-address') +'>',
     to: options.email,
     subject: 'Verify Your '+ req.app.get('project-name') +' Account',
     textPath: 'account/verification/email-text',

--- a/views/contact/index.js
+++ b/views/contact/index.js
@@ -29,7 +29,7 @@ exports.sendMessage = function(req, res){
   
   workflow.on('sendEmail', function() {
     req.app.utility.sendmail(req, res, {
-      from: req.app.get('email-from-name') +' <'+ req.app.get('email-from-address') +'>',
+      from: req.app.get('smtp-from-name') +' <'+ req.app.get('smtp-from-address') +'>',
       replyTo: req.body.email,
       to: req.app.get('admin-email'),
       subject: req.app.get('project-name') +' contact form',

--- a/views/login/forgot/index.js
+++ b/views/login/forgot/index.js
@@ -40,7 +40,7 @@ exports.send = function(req, res){
   
   workflow.on('sendEmail', function(token, user) {
     req.app.utility.sendmail(req, res, {
-      from: req.app.get('email-from-name') +' <'+ req.app.get('email-from-address') +'>',
+      from: req.app.get('smtp-from-name') +' <'+ req.app.get('smtp-from-address') +'>',
       to: user.email,
       subject: 'Reset your '+ req.app.get('project-name') +' password',
       textPath: 'login/forgot/email-text',

--- a/views/signup/index.js
+++ b/views/signup/index.js
@@ -126,7 +126,7 @@ exports.signup = function(req, res){
   
   workflow.on('sendWelcomeEmail', function() {
     req.app.utility.sendmail(req, res, {
-      from: req.app.get('email-from-name') +' <'+ req.app.get('email-from-address') +'>',
+      from: req.app.get('smtp-from-name') +' <'+ req.app.get('smtp-from-address') +'>',
       to: req.body.email,
       subject: 'Your '+ req.app.get('project-name') +' Account',
       textPath: 'signup/email-text',
@@ -368,7 +368,7 @@ exports.signupSocial = function(req, res){
   
   workflow.on('sendWelcomeEmail', function() {
     req.app.utility.sendmail(req, res, {
-      from: req.app.get('email-from-name') +' <'+ req.app.get('email-from-address') +'>',
+      from: req.app.get('smtp-from-name') +' <'+ req.app.get('smtp-from-address') +'>',
       to: req.body.email,
       subject: 'Your '+ req.app.get('project-name') +' Account',
       textPath: 'signup/email-text',


### PR DESCRIPTION
Allow OAuth keys/passwords/other sensitive info to be loaded through the environment instead of requiring them in the file. This should help prevent the accidental pushing of sensitive data when unrelated config changes are made.
