### PR TITLE
Fix: Watch task - Windows 7 env.

### DIFF
--- a/run.js
+++ b/run.js
@@ -100,6 +100,7 @@ else {
       'utilities.js',
       'views/'
     ],
+    ignoreCustomPatterns: /\.tmp/i,
     listener: function(changeType, filePath, fileCurrentStat, filePreviousStat) {
       if ('delete' === changeType) { return; }
       console.log('RUN {*} Change detected: '+ filePath);


### PR DESCRIPTION
- Fix the watch task in Windows 7 env.

Error log: 

```
RUN [?] App started
RUN {*} Change detected: layouts\.sublbb1.tmp

events.js:72 throw er; // Unhandled 'error' event
              ^
Error: ENOENT, stat 'C:\...\drywall\layouts\.sublbb1.tmp'
```
