### PR TITLE
Use bcrypt-nodejs instead of bcrypt 

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "passport-github": "~0.1.5",
     "passport-twitter": "~1.0.2",
     "helmet": "~0.1.2",
-    "bcrypt": "~0.7.7"
+    "bcrypt-nodejs": "~0.0.3"
   },
   "devDependencies": {
     "grunt": "~0.4.1",

--- a/schema/User.js
+++ b/schema/User.js
@@ -42,19 +42,19 @@ exports = module.exports = function(app, mongoose) {
     return returnUrl;
   };
   userSchema.statics.encryptPassword = function(password, done) {
-    var bcrypt = require('bcrypt');
+    var bcrypt = require('bcrypt-nodejs');
     bcrypt.genSalt(10, function(err, salt) {
       if (err) {
         return done(err);
       }
 
-      bcrypt.hash(password, salt, function(err, hash) {
+      bcrypt.hash(password, salt, null, function(err, hash) {
         done(err, hash);
       });
     });
   };
   userSchema.statics.validatePassword = function(password, hash, done) {
-    var bcrypt = require('bcrypt');
+    var bcrypt = require('bcrypt-nodejs');
     bcrypt.compare(password, hash, function(err, res) {
       done(err, res);
     });


### PR DESCRIPTION
... due to Windows compatibility issues with bcrypt. Fixes #124
