### PR TITLE
Add admin<->account navigation

### DIFF
--- a/app.js
+++ b/app.js
@@ -88,6 +88,7 @@ app.configure(function(){
   app.use(function(req, res, next) {
     res.locals.user = {};
     res.locals.user.defaultReturnUrl = req.user && req.user.defaultReturnUrl();
+    res.locals.user.canPlayRoleOfAdmin = req.user && req.user.canPlayRoleOf('admin');
     res.locals.user.username = req.user && req.user.username;
     next();
   });

--- a/layouts/account.jade
+++ b/layouts/account.jade
@@ -21,6 +21,8 @@ html
           ul.nav.navbar-nav
             li: a(href='/account/') My Account
             li: a(href='/account/settings/') Settings
+            if user && user.canPlayRoleOfAdmin
+              li: a(href='/admin/') Admin Area
           ul.nav.navbar-nav.pull-right
             li: a(href='/logout/')
               i.fa.fa-user

--- a/layouts/admin.jade
+++ b/layouts/admin.jade
@@ -20,6 +20,7 @@ html
             span.icon-bar
         div.navbar-collapse.my-navbar-collapse.collapse
           ul.nav.navbar-nav
+            li: a(href='/account/') My Account
             li.dropdown
               a.dropdown-toggle(href='#', data-toggle='dropdown')
                 | System&nbsp;


### PR DESCRIPTION
This commit adds an additional element to each logged-in top nav-bar:
1. On the Admin Area pages, there will be a link to "My Account" which navigates to the account settings area.
2. On the "My Account" area pages, **iff** the user has a linked administator role, there will be a link to the Admin Area.

This change makes the site easier to use and aids discoverability and design comprehension for newcomers to the project.
