### PR TITLE
Fix crash case

### DIFF
--- a/passport.js
+++ b/passport.js
@@ -108,7 +108,7 @@ exports = module.exports = function(app, passport) {
 
   passport.deserializeUser(function(id, done) {
     app.db.models.User.findOne({ _id: id }).populate('roles.admin').populate('roles.account').exec(function(err, user) {
-      if (user.roles && user.roles.admin) {
+      if (user && user.roles && user.roles.admin) {
         user.roles.admin.populate("groups", function(err, admin) {
           done(err, user);
         });


### PR DESCRIPTION
## Problem Description

Server crashes if still-valid user session cookie is passed for a user who was logged in and then deleted in the admin UI.
## Repro Steps
1. Create a new user account and log in to Drywall. Close browser.
2. On second machine, or alternate browser (so as to avoid sending session cookie created in step 1), log in with administrator user/credentials and delete the user created in step 1.
3. Back on original machine/browser, visit the Drywall site.
## Result
- Server side node instance exception thrown / uncaught / crashes
## Expect
- Normal home page to be displayed and session cookie effectively ignored
