### PR TITLE
bower is installing dependencies to public/lib instead of public/vendor ...

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,4 @@
+{
+  "directory": "public/vendor",
+  "json": "bower.json"
+}


### PR DESCRIPTION
While running grunt, it can't find included less files because bower is installing dependencies to public/lib instead of public/vendor.
`.bowerrc` makes sure that they are installed in correct folder
